### PR TITLE
Make `Undef` optional.

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -17,7 +17,7 @@ pub struct Undef;
 #[xml(rename = "value", ns(EPP_XMLNS))]
 pub struct ResultValue {
     /// The `<undef>` element
-    pub undef: Undef,
+    pub undef: Option<Undef>,
 }
 
 /// Type corresponding to the `<extValue>` tag in an EPP response XML
@@ -314,7 +314,7 @@ mod tests {
     use crate::xml;
 
     #[test]
-    fn error() {
+    fn error_with_undef() {
         let xml = get_xml("response/error.xml").unwrap();
         let object = xml::deserialize::<ResponseStatus>(xml.as_str()).unwrap();
 
@@ -323,6 +323,21 @@ mod tests {
         assert_eq!(
             object.result.ext_value.unwrap().reason,
             "545 Object not found"
+        );
+        assert_eq!(object.tr_ids.client_tr_id.unwrap(), CLTRID);
+        assert_eq!(object.tr_ids.server_tr_id, SVTRID);
+    }
+
+    #[test]
+    fn error_with_value() {
+        let xml = get_xml("response/domain_renew_error.xml").unwrap();
+        let object = xml::deserialize::<ResponseStatus>(xml.as_str()).unwrap();
+
+        assert_eq!(object.result.code, ResultCode::ParameterValuePolicyError);
+        assert_eq!(object.result.message, "Parameter value policy error");
+        assert_eq!(
+            object.result.ext_value.unwrap().reason,
+            "V120 Invalid date '2028-01-21'"
         );
         assert_eq!(object.tr_ids.client_tr_id.unwrap(), CLTRID);
         assert_eq!(object.tr_ids.server_tr_id, SVTRID);

--- a/tests/resources/response/domain_renew_error.xml
+++ b/tests/resources/response/domain_renew_error.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.nominet.org.uk/epp/xml/epp-1.0 epp-1.0.xsd">
+  <response>
+    <result code="2306">
+      <msg>Parameter value policy error</msg>
+      <extValue>
+        <value>
+          <domain:curExpDate xmlns:domain="urn:ietf:params:xml:ns:domain-1.0" xsi:schemaLocation="urn:ietf:params:xml:ns:domain-1.0 domain-1.0.xsd">
+                2028-01-21
+          </domain:curExpDate>
+        </value>
+        <reason>V120 Invalid date '2028-01-21'</reason>
+      </extValue>
+    </result>
+    <trID>
+      <clTRID>cltrid:1626454866</clTRID>
+      <svTRID>RO-6879-1627224678242975</svTRID>
+    </trID>
+  </response>
+</epp>


### PR DESCRIPTION
The epp spec says:
```
 *  A <value> element that identifies a client-provided element
    (including XML tag and value) that caused a server error
    condition.
```

The current implementation assumes there will always be a `<undef/>` element in the `<value>` element.

This causes deserialization to fail when the response includes tags and values referencing the data that caused the error, instead of the `<undef/>` element.

By making `Undef` optional, we can just skip deserializing any child elements of `<value>`.